### PR TITLE
Add chrome extension to preview

### DIFF
--- a/on_cmd_preview.js
+++ b/on_cmd_preview.js
@@ -11,7 +11,15 @@ mv('-f', 'build/gh-pages/*', botio.public_dir);
 
 botio.message('#### Published');
 botio.message();
-botio.message('+ Viewer: '+botio.public_url+'/web/viewer.html');
-botio.message('+ Extension: '+botio.public_url+'/extensions/firefox/pdf.js.xpi');
-botio.message('+ Extension (AMO): '+botio.public_url+'/extensions/firefox/pdf.js.amo.xpi');
+botio.message('+ Viewer: ' + botio.public_url + '/web/viewer.html');
+botio.message('+ Firefox Extension: ' + botio.public_url +
+  '/extensions/firefox/pdf.js.xpi');
+botio.message('+ Firefox Extension (AMO): ' + botio.public_url +
+  '/extensions/firefox/pdf.js.amo.xpi');
+
+// Only link to the Chrome extension if it exists
+if (find('-f', botio.public_url + '/extensions/chrome/pdf.js.crx')) {
+  botio.message('+ Chrome Extension: ' + botio.public_url +
+    '/extensions/chrome/pdf.js.crx');
+}
 


### PR DESCRIPTION
This makes the botio generate and link to a .crx chrome extension when the `preview` command is issued.

This will require the server administrator to set up a environment variable called `PDFJS_CHROME_KEY` which points to the .pem key that we'd want to sign the extension package with.
