### PR TITLE
Modify asyncStorage stubs to fix inital page loading in the B2G preview

### DIFF
--- a/b2g_stubs/js/async_storage.js
+++ b/b2g_stubs/js/async_storage.js
@@ -1,9 +1,9 @@
 // Mocks for testing the B2G PDF Viewer in the browser.
 var asyncStorage = {
-  getItem: function() {
-    return {};
+  getItem: function(key, callback) {
+    callback(null);
   },
-  setItem: function() {}
+  setItem: function(key, value) {}
 };
 
 window.navigator.mozSetMessageHandler = function(activity, callback) {


### PR DESCRIPTION
Fixes (reported in https://github.com/mozilla/pdf.js/pull/4076 ):

> B2G viewer is only rendering when scrolling down a little bit. It should render immediately.
