### PR TITLE
Updated test command to use the HTML5 reftest analyzer

### DIFF
--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -64,11 +64,13 @@ silent(true);
       echo();
       echo('>> Copying reftest analyzer files');
       mv('-f', './test/eq.log', botio.public_dir);
-      mv('-f', './test/resources/reftest-analyzer.xhtml', botio.public_dir);
+      mv('-f', './test/resources/reftest-analyzer.html', botio.public_dir);
+      mv('-f', './test/resources/reftest-analyzer.css', botio.public_dir);
+      mv('-f', './test/resources/reftest-analyzer.js', botio.public_dir);
       mv('-f', './test/test_snapshots', botio.public_dir + '/');
 
       botio.message();
-      botio.message('Image differences available at: '+botio.public_url+'/reftest-analyzer.xhtml#web=eq.log');
+      botio.message('Image differences available at: '+botio.public_url+'/reftest-analyzer.html#web=eq.log');
     }
 
     //


### PR DESCRIPTION
Depends on https://github.com/mozilla/pdf.js/pull/4321.
