### PR TITLE
Remove the link to the AMO extension from the preview

### DIFF
--- a/on_cmd_preview.js
+++ b/on_cmd_preview.js
@@ -15,5 +15,3 @@ botio.message();
 botio.message('+ Viewer: '+botio.public_url+'/web/viewer.html');
 botio.message('+ B2G Viewer: '+botio.public_url+'/extensions/b2g/content/web/viewer.html');
 botio.message('+ Extension: '+botio.public_url+'/extensions/firefox/pdf.js.xpi');
-botio.message('+ Extension (AMO): '+botio.public_url+'/extensions/firefox/pdf.js.amo.xpi');
-


### PR DESCRIPTION
Since we're trying to deprecate the AMO extension, let's stop advertising it in every `preview`.