### PR TITLE
Use `gulp` instead of `node make` on the bots

### DIFF
--- a/on_cmd_fonttest.js
+++ b/on_cmd_fonttest.js
@@ -22,7 +22,7 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Font Tests');
 
-exec('node make fonttest', {silent:false, async:true}, function(error, output) {
+exec('gulp fonttest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All font tests passed/g);
 
   if (successMatch) {

--- a/on_cmd_lint.js
+++ b/on_cmd_lint.js
@@ -15,7 +15,7 @@ silent(true);
 echo();
 echo('>> Linting');
 
-exec('node make lint', {silent:false, async:true}, function(error, output) {
+exec('gulp lint', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match('files checked, no errors found');
 
   if (successMatch) {

--- a/on_cmd_makeref.js
+++ b/on_cmd_makeref.js
@@ -16,7 +16,7 @@ echo();
 echo('>> Linting');
 
 // Using {async} to avoid unnecessary CPU usage
-exec('node make lint', {silent:false, async:true}, function(error, output) {
+exec('gulp lint', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match('files checked, no errors found');
 
   if (successMatch) {
@@ -47,7 +47,7 @@ exec('node make lint', {silent:false, async:true}, function(error, output) {
   echo('>> Making references');
 
   // Using {async} to avoid unnecessary CPU usage
-  exec('node make botmakeref', {silent:false, async:true}, function(error, output) {
+  exec('gulp botmakeref', {silent:false, async:true}, function(error, output) {
     var successMatch = output.match(/All regression tests passed/g);
 
     if (successMatch) {

--- a/on_cmd_preview.js
+++ b/on_cmd_preview.js
@@ -4,7 +4,7 @@ exec('npm install');
 
 echo();
 echo('>> Making web site');
-exec('node make web');
+exec('gulp web');
 
 echo();
 echo('>> Moving files');

--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -39,7 +39,7 @@ silent(true);
   echo('>> Running tests');
 
   // Using {async} to avoid unnecessary CPU usage
-  exec('node make bottest', {silent:false, async:true}, function(error, output) {
+  exec('gulp bottest', {silent:false, async:true}, function(error, output) {
     var unitSuccessMatch = output.match(/All unit tests passed/g);
     var fontSuccessMatch = output.match(/All font tests passed/g);
     var regSuccessMatch = output.match(/All regression tests passed/g);

--- a/on_cmd_unittest.js
+++ b/on_cmd_unittest.js
@@ -29,7 +29,7 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Unit Tests');
 
-exec('node make unittest', {silent:false, async:true}, function(error, output) {
+exec('gulp unittest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All unit tests passed/g);
 
   if (successMatch) {

--- a/on_push.js
+++ b/on_push.js
@@ -16,7 +16,7 @@ exec('npm install', {async:false});
 //
 // Publish viewer to gh-pages
 //
-exec('node make web');
+exec('gulp web');
 //
 // Sign the extension
 //
@@ -32,7 +32,7 @@ cd('../..');
 //
 // Publish library to pdfjs-dist
 //
-exec('node make dist');
+exec('gulp dist');
 
 cd('build/dist');
 exec('git push --tags git@github.com:mozilla/pdfjs-dist.git master');


### PR DESCRIPTION
Fixes part of https://github.com/mozilla/pdf.js/issues/7062.