### PR TITLE
Disable Babel translation when running tests on the bots

### DIFF
--- a/on_cmd_fonttest.js
+++ b/on_cmd_fonttest.js
@@ -22,6 +22,8 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Font Tests');
 
+process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+
 exec('gulp fonttest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All font tests passed/g);
 

--- a/on_cmd_makeref.js
+++ b/on_cmd_makeref.js
@@ -46,6 +46,8 @@ exec('gulp lint', {silent:false, async:true}, function(error, output) {
   echo();
   echo('>> Making references');
 
+  process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+
   // Using {async} to avoid unnecessary CPU usage
   exec('gulp botmakeref', {silent:false, async:true}, function(error, output) {
     var successMatch = output.match(/All regression tests passed/g);

--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -38,6 +38,8 @@ silent(true);
   echo();
   echo('>> Running tests');
 
+  process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+
   // Using {async} to avoid unnecessary CPU usage
   exec('gulp bottest', {silent:false, async:true}, function(error, output) {
     var unitSuccessMatch = output.match(/All unit tests passed/g);

--- a/on_cmd_unittest.js
+++ b/on_cmd_unittest.js
@@ -29,6 +29,8 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Unit Tests');
 
+process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+
 exec('gulp unittest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All unit tests passed/g);
 


### PR DESCRIPTION
Not only should this reduce the runtime of (in particular) the Windows bot, but it will also allow us to actually test the source code as-is rather than its Babel translated version.
Since the bots are running the current versions of Firefox/Chrome, testing ES6 code as-is should thus not be an issue.