### PR TITLE
Update the environment variable used to disable Babel translation

### DIFF
--- a/on_cmd_fonttest.js
+++ b/on_cmd_fonttest.js
@@ -22,7 +22,7 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Font Tests');
 
-process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
 
 exec('gulp fonttest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All font tests passed/g);

--- a/on_cmd_makeref.js
+++ b/on_cmd_makeref.js
@@ -46,7 +46,7 @@ exec('gulp lint', {silent:false, async:true}, function(error, output) {
   echo();
   echo('>> Making references');
 
-  process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+  process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
 
   // Using {async} to avoid unnecessary CPU usage
   exec('gulp botmakeref', {silent:false, async:true}, function(error, output) {

--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -38,7 +38,7 @@ silent(true);
   echo();
   echo('>> Running tests');
 
-  process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+  process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
 
   // Using {async} to avoid unnecessary CPU usage
   exec('gulp bottest', {silent:false, async:true}, function(error, output) {

--- a/on_cmd_unittest.js
+++ b/on_cmd_unittest.js
@@ -29,7 +29,7 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Unit Tests');
 
-process.env['PDFJS_NEXT'] = 'true'; // Disable Babel translation.
+process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
 
 exec('gulp unittest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All unit tests passed/g);


### PR DESCRIPTION
`PDFJS_NEXT` was replaced with the (more suitably named) `SKIP_BABEL` variable in https://github.com/mozilla/pdf.js/pull/9033.

/cc @brendandahl, @yurydelendik, @timvandermeij 