### PR TITLE
Remove `SKIP_BABEL = true` since that's now the default in the PDF.js repository

### DIFF
--- a/on_cmd_fonttest.js
+++ b/on_cmd_fonttest.js
@@ -22,8 +22,6 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Font Tests');
 
-process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
-
 exec('gulp fonttest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All font tests passed/g);
 

--- a/on_cmd_makeref.js
+++ b/on_cmd_makeref.js
@@ -46,8 +46,6 @@ exec('gulp lint', {silent:false, async:true}, function(error, output) {
   echo();
   echo('>> Making references');
 
-  process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
-
   // Using {async} to avoid unnecessary CPU usage
   exec('gulp botmakeref', {silent:false, async:true}, function(error, output) {
     var successMatch = output.match(/All regression tests passed/g);

--- a/on_cmd_preview.js
+++ b/on_cmd_preview.js
@@ -12,4 +12,5 @@ mv('-f', 'build/gh-pages/*', botio.public_dir);
 
 botio.message('#### Published');
 botio.message();
-botio.message('+ Viewer: '+botio.public_url+'/web/viewer.html');
+botio.message('+ Viewer: ' + botio.public_url + '/web/viewer.html');
+botio.message('+ Viewer (ES5): ' + botio.public_url + '/es5/web/viewer.html');

--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -38,8 +38,6 @@ silent(true);
   echo();
   echo('>> Running tests');
 
-  process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
-
   // Using {async} to avoid unnecessary CPU usage
   exec('gulp bottest', {silent:false, async:true}, function(error, output) {
     var unitSuccessMatch = output.match(/All unit tests passed/g);

--- a/on_cmd_unittest.js
+++ b/on_cmd_unittest.js
@@ -29,8 +29,6 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Unit Tests');
 
-process.env['SKIP_BABEL'] = 'true'; // Disable Babel translation.
-
 exec('gulp unittest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All unit tests passed/g);
 


### PR DESCRIPTION
See https://github.com/mozilla/pdf.js/pull/11241