### PR TITLE
Rename `es5` to `legacy`

### DIFF
--- a/on_cmd_preview.js
+++ b/on_cmd_preview.js
@@ -13,4 +13,4 @@ mv('-f', 'build/gh-pages/*', botio.public_dir);
 botio.message('#### Published');
 botio.message();
 botio.message('+ Viewer: ' + botio.public_url + '/web/viewer.html');
-botio.message('+ Viewer (ES5): ' + botio.public_url + '/es5/web/viewer.html');
+botio.message('+ Viewer (legacy): ' + botio.public_url + '/legacy/web/viewer.html');


### PR DESCRIPTION
See https://github.com/mozilla/pdf.js/pull/12978