### PR TITLE
Include a detailed summary of the ref-test failures in the output from `on_cmd_test.js`

### DIFF
--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -69,6 +69,29 @@ silent(true);
       botio.message('+ **Regression tests:** FAILED');
       fail = true; // non-fatal, continue
 
+      // Include a detailed summary of the ref-test failures.
+      if (output.match(/OHNOES!  Some tests failed!/g)) {
+        const details = [];
+
+        const numErrors = output.match(/  errors: \d+/g);
+        if (numErrors) {
+          details.push(numErrors[0]);
+        }
+        const numEqFailures = output.match(/  different ref\/snapshot: \d+/g);
+        if (numEqFailures) {
+          details.push(numEqFailures[0]);
+        }
+        const numFBFFailures = output.match(/  different first\/second rendering: \d+/g);
+        if (numFBFFailures) {
+          details.push(numFBFFailures[0]);
+        }
+
+        if (details.length > 0) {
+          botio.message();
+          botio.message("```\n" + details.join("\n") + "\n```");
+        }
+      }
+
       //
       // Copy reftest analyzer files
       //


### PR DESCRIPTION
Currently it's way too easy to *accidentally* overlook breaking errors in the test-output, especially for ref-test failures that don't show up in the reftest-analyzer.