### PR TITLE
Try to fix logging of the detailed ref-test failures (PR 30 follow-up)

### DIFF
--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -88,7 +88,11 @@ silent(true);
 
         if (details.length > 0) {
           botio.message();
-          botio.message("```\n" + details.join("\n") + "\n```");
+          botio.message("```");
+          for (const line of details) {
+            botio.message(line);
+          }
+          botio.message("```");
         }
       }
 


### PR DESCRIPTION
Apparently I didn't understand the limitations of `botio.message` well enough, since the logging didn't work as intended so hopefully this is better; sorry about the churn here!