### PR TITLE
Drop the beta logic from the release script

### DIFF
--- a/on_release.js
+++ b/on_release.js
@@ -17,15 +17,8 @@ exec('npm install', {async:true}, function () {
 exec('gulp dist', {async:true}, function() {
 
 cd('build/dist');
-if (jobInfo.prerelease) {
-  // The release hook doesn't differentiate between making a new release
-  // and updating an existing release, so both actions will trigger this
-  // bot action. However, we only want to push to `pdfjs-dist` when making
-  // a new prerelease, because otherwise updating an existing prerelease
-  // to make it stable would push the same commit again.
-  exec('git push --tags git@github.com:mozilla/pdfjs-dist.git master');
-}
-exec('npm publish' + (jobInfo.prerelease ? ' --tag next' : ''));
+exec('git push --tags git@github.com:mozilla/pdfjs-dist.git master');
+exec('npm publish');
 cd('../..');
 
 }); // gulp dist


### PR DESCRIPTION
From now on we only make stable releases, so the beta logic should be removed. This also ensures that we push to the `pdfjs-dist` repository on every stable release, which currently doesn't work because that line is only triggered for beta releases.

Fixes a part of [#14226](https://github.com/mozilla/pdf.js/issues/14226).

/cc @Snuffleupagus 