### PR TITLE
Remove linting from the `makeref` command, and use the locally-installed version of Gulp instead a globally-installed one

### DIFF
--- a/on_cmd_browsertest.js
+++ b/on_cmd_browsertest.js
@@ -37,7 +37,7 @@ silent(true);
   echo('>> Regression tests');
 
   // Using {async} to avoid unnecessary CPU usage
-  exec('gulp botbrowsertest', {silent:false, async:true}, function(error, output) {
+  exec('npx gulp botbrowsertest', {silent:false, async:true}, function(error, output) {
     var regSuccessMatch = output.match(/All regression tests passed/g);
 
     if (regSuccessMatch) {

--- a/on_cmd_integrationtest.js
+++ b/on_cmd_integrationtest.js
@@ -27,7 +27,7 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Integration Tests');
 
-exec('gulp integrationtest', {silent:false, async:true}, function(error, output) {
+exec('npx gulp integrationtest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All integration tests passed/g);
 
   if (successMatch) {

--- a/on_cmd_makeref.js
+++ b/on_cmd_makeref.js
@@ -1,28 +1,8 @@
 var botio = require(process.env['BOTIO_MODULE']);
 require('shelljs/global');
 
-var fail = false;
-
 exec('npm install', {async:true}, function() {
-
-silent(true);
-
-//
-// Lint
-//
-echo();
-echo('>> Linting');
-
-// Using {async} to avoid unnecessary CPU usage
-exec('gulp lint', {silent:false, async:true}, function(error, output) {
-  var successMatch = output.match('files checked, no errors found');
-
-  if (successMatch) {
-    botio.message('+ **Lint:** Passed');
-  } else {
-    botio.message('+ **Lint:** FAILED');
-    fail = true; // non-fatal, continue
-  }
+  silent(true);
 
   //
   // Get PDFs from local cache
@@ -80,9 +60,5 @@ exec('gulp lint', {silent:false, async:true}, function(error, output) {
     echo('>> Updating local PDF cache')
     mkdir('-p', __dirname+'/pdf-cache');
     cp('./test/pdfs/*.pdf', __dirname+'/pdf-cache');
-
-    if (fail)
-      exit(1);
   }); // exec makeref
-}); // exec lint
 }); // npm install

--- a/on_cmd_makeref.js
+++ b/on_cmd_makeref.js
@@ -25,7 +25,7 @@ exec('npm install', {async:true}, function() {
   echo('>> Making references');
 
   // Using {async} to avoid unnecessary CPU usage
-  exec('gulp botmakeref', {silent:false, async:true}, function(error, output) {
+  exec('npx gulp botmakeref', {silent:false, async:true}, function(error, output) {
     var successMatch = output.match(/All regression tests passed/g);
 
     if (successMatch) {

--- a/on_cmd_preview.js
+++ b/on_cmd_preview.js
@@ -4,7 +4,7 @@ exec('npm install');
 
 echo();
 echo('>> Making web site');
-exec('gulp web');
+exec('npx gulp web');
 
 echo();
 echo('>> Moving files');

--- a/on_cmd_test.js
+++ b/on_cmd_test.js
@@ -37,7 +37,7 @@ silent(true);
   echo('>> Running tests');
 
   // Using {async} to avoid unnecessary CPU usage
-  exec('gulp bottest', {silent:false, async:true}, function(error, output) {
+  exec('npx gulp bottest', {silent:false, async:true}, function(error, output) {
     var integrationSuccessMatch = output.match(/All integration tests passed/g);
     var unitSuccessMatch = output.match(/All unit tests passed/g);
     var regSuccessMatch = output.match(/All regression tests passed/g);

--- a/on_cmd_unittest.js
+++ b/on_cmd_unittest.js
@@ -27,7 +27,7 @@ cp('-f', __dirname+'/test-files/browser_manifest.json', './test/resources/browse
 echo();
 echo('>> Unit Tests');
 
-exec('gulp unittest', {silent:false, async:true}, function(error, output) {
+exec('npx gulp unittest', {silent:false, async:true}, function(error, output) {
   var successMatch = output.match(/All unit tests passed/g);
 
   if (successMatch) {

--- a/on_cmd_xfatest.js
+++ b/on_cmd_xfatest.js
@@ -37,7 +37,7 @@ silent(true);
   echo('>> Running tests');
 
   // Using {async} to avoid unnecessary CPU usage
-  exec('gulp botxfatest', {silent:false, async:true}, function(error, output) {
+  exec('npx gulp botxfatest', {silent:false, async:true}, function(error, output) {
     var integrationSuccessMatch = output.match(/All integration tests passed/g);
     var unitSuccessMatch = output.match(/All unit tests passed/g);
     var regSuccessMatch = output.match(/All regression tests passed/g);

--- a/on_release.js
+++ b/on_release.js
@@ -14,12 +14,12 @@ exec('npm install', {async:true}, function () {
 //
 // Publish library to pdfjs-dist
 //
-exec('gulp dist', {async:true}, function() {
+exec('npx gulp dist', {async:true}, function() {
 
 cd('build/dist');
 exec('git push --tags git@github.com:mozilla/pdfjs-dist.git master');
 exec('npm publish');
 cd('../..');
 
-}); // gulp dist
+}); // npx gulp dist
 }); // npm install


### PR DESCRIPTION
The commit messages contain more details about the individual changes.

Fixes a part of https://github.com/mozilla/pdf.js/issues/11851.
Unblocks https://github.com/mozilla/pdf.js/pull/18197.